### PR TITLE
Make bitrate properties public

### DIFF
--- a/Sources/NetworkTrafficStatistics.swift
+++ b/Sources/NetworkTrafficStatistics.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public struct Bitrate {
-    var download: UInt32
-    var upload: UInt32
+    public var download: UInt32
+    public var upload: UInt32
 }
 
 public class NetworkTrafficStatistics {


### PR DESCRIPTION
`VPNManagerDelegate` provides method called `func VpnManagerPacketTransmitted(with bitrate: OpenVPNXor.Bitrate)` which can be very helpful to monitor network status and inform user on current bitrate. However actual bitrate information is currently under default `internal` visibility and can't be read from the host app.