### PR TITLE
Add macOS support to podspec

### DIFF
--- a/OpenVPNXor.podspec
+++ b/OpenVPNXor.podspec
@@ -24,9 +24,12 @@ The library is designed to use in conjunction with NetworkExtension framework an
   s.osx.deployment_target = '10.14'
   s.source            = { :http => 'https://github.com/FuturraGroup/OpenVPNXor/raw/main/releases/2.2/OpenVPNXor.framework.zip' }
   s.ios.vendored_frameworks = 'OpenVPNXor.framework'
-  s.ios.deployment_target = '12.0'
- s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.osx.vendored_frameworks = 'OpenVPNXor.framework'
+  s.source_files = 'Sources/**/*.{swift,h,m,mm}'
+  s.public_header_files = 'Sources/**/*.h'
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.swift_version = '5.0'
 
 
   

--- a/OpenVPNXor.podspec
+++ b/OpenVPNXor.podspec
@@ -20,7 +20,8 @@ The library is designed to use in conjunction with NetworkExtension framework an
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Sergey Zhuravel' => 'sergey.zhuravel@icloud.com' }
 
-  s.platform            = :ios, "12.0"
+  s.ios.deployment_target = '12.0'
+  s.osx.deployment_target = '10.14'
   s.source            = { :http => 'https://github.com/FuturraGroup/OpenVPNXor/raw/main/releases/2.2/OpenVPNXor.framework.zip' }
   s.ios.vendored_frameworks = 'OpenVPNXor.framework'
   s.ios.deployment_target = '12.0'


### PR DESCRIPTION
This PR adds official macOS support to the podspec by setting s.osx.deployment_target = '10.14'.
The library is already compatible with macOS, this just allows CocoaPods to install it for macOS targets.